### PR TITLE
Fixed namespace in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The package includes [staudenmeir/laravel-migration-views](https://github.com/st
 can use its methods to rename and drop views:
 
 ```php
-use Staudenmeir\LaravelMergedRelations\Facades\Schema;
+use Staudenmeir\LaravelMigrationViews\Facades\Schema;
 
 Schema::renameView('all_comments', 'user_comments');
 


### PR DESCRIPTION
`Staudenmeir\LaravelMergedRelations\Facades\Schema` doesn't seem to have ::drop() method and text points to views package as well. I assume `Staudenmeir\LaravelMigrationViews\Facades\Schema` was intended.